### PR TITLE
Improve security and authentication tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DJANGO_SECRET_KEY=your-secret-key
+# Optional OpenAI key for agent endpoint
+OPENAI_API_KEY=your-openai-key
+

--- a/README.md
+++ b/README.md
@@ -1,8 +1,48 @@
-Step 1: ~ cd redis-table
-Step 2: ~ src/redis-server
+# Course Web App Backend
 
-Optional:
-Step 1: ~ sudo cp src/redis-server /usr/local/bin/
-        ~ sudo cp src/redis-cli /usr/local/bin/
+This is a small Django REST API providing basic course management and a simple OpenAI assistant endpoint.
 
-Step 2: redis-server
+## Setup
+
+1. **Install dependencies**
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+2. **Configure environment variables**
+
+Copy `.env.example` to `.env` and update the values:
+
+```bash
+cp .env.example .env
+```
+
+`DJANGO_SECRET_KEY` is required. `OPENAI_API_KEY` is optional and used by the agent endpoint.
+
+3. **Start Redis** (required for caching)
+
+```bash
+redis-server
+```
+
+4. **Apply migrations**
+
+```bash
+python manage.py migrate
+```
+
+5. **Run the development server**
+
+```bash
+python manage.py runserver
+```
+
+6. **Run tests**
+
+```bash
+python manage.py test
+```
+

--- a/config/settings.py
+++ b/config/settings.py
@@ -20,7 +20,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-yjn=se#^+2uuq1d+3u08k3292@1!xuyc*=@i1+5lx-683zymmz'
+SECRET_KEY = os.getenv('DJANGO_SECRET_KEY', 'change-me')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/user/serializers.py
+++ b/user/serializers.py
@@ -12,7 +12,7 @@ class RegisterSerializer(serializers.ModelSerializer):
         fields = ('id', 'username', 'email', 'password')
         
     def create(self, validated_data):
-        user = User.object.create_user(
+        user = User.objects.create_user(
             username=validated_data['username'],
             email=validated_data['email'],
             password=validated_data['password']

--- a/user/tests.py
+++ b/user/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/user/tests/test_auth_api.py
+++ b/user/tests/test_auth_api.py
@@ -1,0 +1,36 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+from django.contrib.auth.models import User
+
+
+class AuthenticationFlowTest(APITestCase):
+    def test_register_login_and_access(self):
+        register_url = reverse('register')
+        data = {
+            'username': 'john',
+            'email': 'john@example.com',
+            'password': 'pass1234'
+        }
+        res = self.client.post(register_url, data)
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+
+        login_url = reverse('login')
+        login_res = self.client.post(login_url, {
+            'username': 'john',
+            'password': 'pass1234'
+        })
+        self.assertEqual(login_res.status_code, status.HTTP_200_OK)
+        access = login_res.data.get('access')
+        self.assertIsNotNone(access)
+
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access}')
+        list_url = reverse('course-list')
+        resp = self.client.get(list_url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_courses_requires_authentication(self):
+        url = reverse('course-list')
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+


### PR DESCRIPTION
## Summary
- load Django secret key from an environment variable
- document setup and usage in README
- fix `RegisterSerializer` bug
- provide `.env.example`
- add auth API tests for registration and JWT usage
- remove obsolete `user/tests.py`

## Testing
- `python -m venv venv`
- `source venv/bin/activate`
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688b184c382c833286914ab7b8d046ec